### PR TITLE
Parse version numbers for alpha, beta, rc releases

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -12,7 +12,8 @@ cmd="$cmd $releases_path"
 function sort_versions() {
     sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' \
     | LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n \
-    | awk '{print $2}' 
+    | awk '{print $2}' \
+    | paste -s -d" " -
 }
 
 function extract_versions_numbers() {

--- a/bin/list-all
+++ b/bin/list-all
@@ -12,12 +12,11 @@ cmd="$cmd $releases_path"
 function sort_versions() {
     sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' \
     | LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n \
-    | awk '{print $2}' \
-    | paste -s -d" " -
+    | awk '{print $2}' 
 }
 
 function extract_versions_numbers() {
-    grep -o "name\": \"[0-9]\+.[0-9]\+.[0-9]\+" | sed 's/name": "//'
+    grep -o "name\": \".*" | sed 's/name": "\(.*\)\",/\1/'
 }
 
 # Fetch all tags, and get only second column. Then remove all unnecesary characters.

--- a/bin/list-all
+++ b/bin/list-all
@@ -17,7 +17,7 @@ function sort_versions() {
 }
 
 function extract_versions_numbers() {
-    grep -o "name\": \".*" | sed 's/name": "\(.*\)\",/\1/'
+    grep -o "\"name\": \"[0-9]\+.[0-9]\+.[0-9]\+-\?\w\+\"," | sed 's/"name": "\(.*\)",/\1/'
 }
 
 # Fetch all tags, and get only second column. Then remove all unnecesary characters.


### PR DESCRIPTION
The `list-all` command should print out the correct names of each version, even if that version is an alpha, beta, or rc release.

## Current Behavior

```shell
$ asdf list-all io
2008.03.30
2010.06.06
2011.09.03
2011.09.05
2011.09.06
2011.09.12
2013.12.04
2015.11.11
2017.09.06
2019.05.22
```

## Expected Behavior

```shell
$ bin/list-all
2008.03.30
2010.06.06
2011.09.03
2011.09.05
2011.09.06
2011.09.12
2013.12.04
2015.11.11
2017.09.06
2019.05.22-alpha
```