### PR TITLE
Simplify scripts

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -11,6 +11,8 @@ git clone --recursive --branch "$ASDF_INSTALL_VERSION" --depth 1 https://github.
 (
     cd "$source_path"
 
+    # Only for versions before 2019.05.22-alpha, since after this version addons were
+    # separated from the main repo and are now installed with eerie
     if [[ -z "${WITH_IO_ADDONS:-}" ]]; then
         sed -i.bak "s|add_subdirectory(addons)|#add_subdirectory(addons)|" CMakeLists.txt
     fi

--- a/bin/install
+++ b/bin/install
@@ -3,52 +3,18 @@
 set -eu
 [ "${BASH_VERSINFO[0]}" -ge 3 ] && set -o pipefail
 
-die () {
-    echo "$1"
-    exit 1
-}
+tmp_download_dir=$(mktemp -dt io_build_XXXXXX)
+source_path="$tmp_download_dir/io-${ASDF_INSTALL_TYPE}-${ASDF_INSTALL_VERSION}"
 
-get_download_file_path() {
-    local install_type=$1
-    local version=$2
-    local tmp_download_dir=$3
+git clone --recursive --branch "$ASDF_INSTALL_VERSION" --depth 1 https://github.com/IoLanguage/io "$source_path"
 
-    local pkg_name="io-${install_type}-${version}"
+(
+    cd "$source_path"
 
-    echo "$tmp_download_dir/$pkg_name"
-}
+    if [[ -z "${WITH_IO_ADDONS:-}" ]]; then
+        sed -i.bak "s|add_subdirectory(addons)|#add_subdirectory(addons)|" CMakeLists.txt
+    fi
 
-clone_source_repository() {
-    local install_type=$1
-    local version=$2
-    local download_path=$3
-    local clone_url="https://github.com/IoLanguage/io"
-
-    git clone --recursive --branch "$version" --depth 1 $clone_url "$download_path"
-}
-
-install_io () {
-    local install_type=$1
-    local version=$2
-    local install_path=$3
-    local tmp_download_dir
-    tmp_download_dir=$(mktemp -dt io_build_XXXXXX)
-
-    local source_path
-    source_path=$(get_download_file_path "$install_type" "$version" "$tmp_download_dir")
-
-    clone_source_repository "$install_type" "$version" "$source_path"
-
-    (
-        cd "$source_path"
-
-        if [[ -z "${WITH_IO_ADDONS:-}" ]]; then
-            sed -i.bak "s|add_subdirectory(addons)|#add_subdirectory(addons)|" CMakeLists.txt
-        fi
-
-        cmake -DCMAKE_INSTALL_PREFIX="$install_path" -DCMAKE_BUILD_TYPE=release -DWITHOUT_EERIE=1
-        make install
-    )
-}
-
-install_io "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"
+    cmake -DCMAKE_INSTALL_PREFIX="$ASDF_INSTALL_PATH" -DCMAKE_BUILD_TYPE=release -DWITHOUT_EERIE=1
+    make install
+)

--- a/bin/list-all
+++ b/bin/list-all
@@ -16,10 +16,13 @@ function sort_versions() {
     | paste -s -d" " -
 }
 
+# Matches the following lines formats:
+# - "name": "2019.02.03"
+# - "name": "2019.02.03-alpha"
+# As to be able to match stable Io releases and alpha/beta ones too
 function extract_versions_numbers() {
     grep -o "\"name\": \"[0-9]\+.[0-9]\+.[0-9]\+-\?\w\+\"," | sed 's/"name": "\(.*\)",/\1/'
 }
 
-# Fetch all tags, and get only second column. Then remove all unnecesary characters.
 versions=$(eval "$cmd" | extract_versions_numbers | sort_versions)
 echo "$versions"


### PR DESCRIPTION
- Add some doc to `bin/list-all#extract_version_numbers`
- Simplify `bin/install` script  by removing all the unnecessary functions (all of them hehe)
- Little doc about `WITHOUT_IO_ADDONS` env